### PR TITLE
Converter script changes

### DIFF
--- a/GMPWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/GMPWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -87,10 +87,11 @@ def resolveGroup(lines, proc, execGroup):
           lines.append("algList.append(%s)" % child.get('name').replace(".", "_"))
 
 
-def getExecutingProcessors(lines, tree, optProcessors=False):
+def getExecutingProcessors(lines, tree):
   """ compare the list of processors to execute, order matters """
   execProc = tree.findall('execute/*')
   execGroup = tree.findall('group')
+  optProcessors = False
 
   for proc in execProc:
     if proc.tag == "if":
@@ -184,7 +185,7 @@ def generateGaudiSteering(tree):
   createLcioReader(lines, globParams)
   convertProcessors(lines, tree, globParams)
   optProcessors = getExecutingProcessors(lines, tree)
-  if (optProcessors == True):
+  if optProcessors:
     print('Optional Processors were found!')
     print('Please uncomment the desired ones at the bottom of the resulting file\n')
   createFooter(lines, globParams)
@@ -193,9 +194,9 @@ def generateGaudiSteering(tree):
 
 def run():
   args = sys.argv
-  if len(args) != 2:
+  if len(args) != 3:
     print("incorrect number of input files, need one marlin steering files as argument")
-    print("convertMarlinSteeringToGaudi.py file1.xml")
+    print("convertMarlinSteeringToGaudi.py inputFile.xml outputFile.py")
     exit(1)
 
   try:
@@ -204,11 +205,8 @@ def run():
     print("Exception when getting trees: %r " % ex)
     exit(1)
 
-  wf_path = os.path.splitext(args[1])[0] + '.py'
-  wf_file = open(wf_path, 'w')
-
+  wf_file = open(args[2], 'w')
   wf_file.write("\n".join(generateGaudiSteering(tree)))
-  # print("\n".join(generateGaudiSteering(tree)))
 
 if __name__ == "__main__":
   run()

--- a/GMPWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/GMPWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -87,7 +87,7 @@ def resolveGroup(lines, proc, execGroup):
           lines.append("algList.append(%s)" % child.get('name').replace(".", "_"))
 
 
-def getExecutingProcessors(lines, tree):
+def getExecutingProcessors(lines, tree, optProcessors=False):
   """ compare the list of processors to execute, order matters """
   execProc = tree.findall('execute/*')
   execGroup = tree.findall('group')
@@ -96,12 +96,13 @@ def getExecutingProcessors(lines, tree):
     if proc.tag == "if":
       for child in proc:
         if child.tag == "processor":
-          # lines.append("# algList.append(%s)" % child.get('name').replace(".", "_"))
+          optProcessors = True
           lines.append("# algList.append(%s)  # %s" % (child.get('name').replace(".", "_"), proc.get('condition')))
     if proc.tag == "processor":
       lines.append("algList.append(%s)" % proc.get('name'))
     if proc.tag == "group":
       resolveGroup(lines, proc.get('name'), execGroup)
+  return optProcessors
 
 
 def createHeader(lines):
@@ -182,7 +183,10 @@ def generateGaudiSteering(tree):
   createHeader(lines)
   createLcioReader(lines, globParams)
   convertProcessors(lines, tree, globParams)
-  getExecutingProcessors(lines, tree)
+  optProcessors = getExecutingProcessors(lines, tree)
+  if (optProcessors == True):
+    print('Optional Processors were found!')
+    print('Please uncomment the desired ones at the bottom of the resulting file\n')
   createFooter(lines, globParams)
   return lines
 

--- a/GMPWrapper/scripts/convertMarlinSteeringToGaudi.py
+++ b/GMPWrapper/scripts/convertMarlinSteeringToGaudi.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 import sys
 from copy import deepcopy
+import os
 
 from xml.etree.ElementTree import ElementTree
 
@@ -199,8 +200,11 @@ def run():
     print("Exception when getting trees: %r " % ex)
     exit(1)
 
-  print("\n".join(generateGaudiSteering(tree)))
+  wf_path = os.path.splitext(args[1])[0] + '.py'
+  wf_file = open(wf_path, 'w')
 
+  wf_file.write("\n".join(generateGaudiSteering(tree)))
+  # print("\n".join(generateGaudiSteering(tree)))
 
 if __name__ == "__main__":
   run()


### PR DESCRIPTION
BEGINRELEASENOTES
- convertMarlinSteeringToGaudi.py
  - The script will now generate the output file, instead of printing it. 
  - This will break whatever scripts are using the converter by piping its output to generate a file.
  - It now warns on output about having to uncomment optional processors.

ENDRELEASENOTES
