### PR TITLE
Compile with hsf for ci

### DIFF
--- a/.github/scripts/copy_contents.sh
+++ b/.github/scripts/copy_contents.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-### Run like this beacuse docker exec won't do bash expansion for the *
-cp -r /gaudi/* /shared_gaudi_volume/

--- a/.github/scripts/gmp_build_and_test.sh
+++ b/.github/scripts/gmp_build_and_test.sh
@@ -2,16 +2,13 @@
 
 yum -y install make git wget
 
-source /cvmfs/clicdp.cern.ch/iLCSoft/lcg/97/nightly/x86_64-centos7-gcc8-opt/init_ilcsoft.sh
+source /cvmfs/sw.hsf.org/key4hep/setup.sh
 
 # Compile GMP pointing to Gaudi
 cd /GMP
 mkdir build install; cd build
 cmake \
   -DCMAKE_INSTALL_PREFIX=../install \
-  -DGaudi_DIR="/shared_gaudi_volume" \
-  -DGaudiProject_DIR="/shared_gaudi_volume/cmake" \
-  -DHOST_BINARY_TAG=skylake-centos7-gcc8-opt \
   .. && \
 make -j 2 && \
 make install && \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install CVMFS
       run: |
+        # Get CVMFS working
         wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
         sudo dpkg -i cvmfs-release-latest_all.deb
         sudo apt-get update
@@ -25,7 +26,7 @@ jobs:
         CVMFS_HTTP_PROXY=DIRECT
         CVMFS_CACHE_BASE='/var/lib/cvmfs'
         CVMFS_FORCE_SIGNING='yes'
-        CVMFS_REPOSITORIES='clicdp.cern.ch,sft.cern.ch,geant4.cern.ch'
+        CVMFS_REPOSITORIES='clicdp.cern.ch,sft.cern.ch,geant4.cern.ch,sw.hsf.org'
         CVMFS_SEND_INFO_HEADER=no
         EOF
 
@@ -35,31 +36,22 @@ jobs:
         ls /cvmfs/sft.cern.ch
         ls /cvmfs/geant4.cern.ch
         ls /cvmfs/clicdp.cern.ch
-
-        mkdir shared_gaudi_volume
-        ls -l
+        ls /cvmfs/sw.hsf.org
 
         sudo cvmfs_config probe
         sudo cvmfs_config status
+
     - name: Start containers
       run: |
         docker run \
-            -it --name Gaudi_cont \
-            -v /home/runner/work/GMP/GMP:/GMP \
-            -v /home/runner/work/GMP/shared_gaudi_volume:/shared_gaudi_volume:Z \
-            -e VIEW=${{ matrix.LCG }} \
-            -d fdplacido/gaudi-gmp /bin/bash
-
-        docker run \
             -it --name GMP_CI \
             -v /home/runner/work/GMP/GMP:/GMP \
-            -v /home/runner/work/GMP/shared_gaudi_volume:/shared_gaudi_volume:Z \
             -v /cvmfs/sft.cern.ch:/cvmfs/sft.cern.ch \
             -v /cvmfs/clicdp.cern.ch:/cvmfs/clicdp.cern.ch \
             -v /cvmfs/geant4.cern.ch:/cvmfs/geant4.cern.ch:Z \
+            -v /cvmfs/sw.hsf.org:/cvmfs/sw.hsf.org: \
             -e VIEW=${{ matrix.LCG }} \
             -d clicdp/cc7-lcg96b /bin/bash
-    - name: Compile Gaudi, GMP and run test
+    - name: Compile GMP and run test
       run: |
-        docker exec Gaudi_cont ./GMP/.github/scripts/copy_contents.sh
         docker exec GMP_CI ./GMP/.github/scripts/gmp_build_and_test.sh

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Add the iLCSoft LCG 97 view to your system, then indicate the paths to cmake for
 git clone https://github.com/andresailer/GMP.git
 cd GMP
 
-source /cvmfs/clicdp.cern.ch/iLCSoft/lcg/97/nightly/x86_64-centos7-gcc8-opt/init_ilcsoft.sh
+source /cvmfs/sw.hsf.org/key4hep/setup.sh
 
 mkdir build; cd build
 
-cmake -DGaudi_DIR="path/to/GaudiInstallation" -DGaudiProject_DIR="path/to/GaudiInstallation" ..
+cmake ..
 
 mkdir ../../gmp_install
 cmake -DCMAKE_INSTALL_PREFIX=../../gmp_install ..

--- a/cmake/gaudi_binary_tag.cmake
+++ b/cmake/gaudi_binary_tag.cmake
@@ -1,31 +1,7 @@
 # get_host_binary_tag.py is not executable in normal gaudi installations,
 # which silently fails in the BinaryTagUtils from Gaudi
 
-if (NOT HOST_BINARY_TAG)
-
-  find_program(HOST_BINARY_TAG_COMMAND
-               NAMES host-binary-tag get_host_binary_tag.py
-               PATHS "${Gaudi_DIR}/cmake")
-  execute_process(COMMAND python ${HOST_BINARY_TAG_COMMAND}
-     OUTPUT_VARIABLE HOST_BINARY_TAG
-     RESULT_VARIABLE HOST_TAG_RETURN
-     ERROR_VARIABLE  HOST_BINARY_ERROR
-     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  IF(NOT HOST_BINARY_TAG_COMMAND OR HOST_TAG_RETURN OR NOT HOST_BINARY_TAG)
-    message(SEND_ERROR "Failed to execute ${HOST_BINARY_TAG_COMMAND}")
-    message(SEND_ERROR "HOST_BINARY_TAG: ${HOST_BINARY_TAG}")
-    message(SEND_ERROR "Return Code ${HOST_TAG_RETURN}")
-    message(SEND_ERROR "Error Message ${HOST_BINARY_ERROR}")
-  ENDIF()
-  set(HOST_BINARY_TAG ${HOST_BINARY_TAG} CACHE STRING "BINARY_TAG of the host")
-  set(BINARY_TAG ${HOST_BINARY_TAG})
-
-  message(STATUS "Using      binary tag ${BINARY_TAG}")
-  message(STATUS "Using host binary tag ${HOST_BINARY_TAG}")
-
-else()
-
-  set(BINARY_TAG ${HOST_BINARY_TAG})
-
+if( NOT DEFINED ENV{LCG_VERSION})
+  set(HOST_BINARY_TAG x86_64-linux-gcc9-opt)
 endif()
-
+find_package(GaudiProject)

--- a/test/scripts/test_clicReconstruction.sh
+++ b/test/scripts/test_clicReconstruction.sh
@@ -20,7 +20,7 @@ if [ ! -f testSimulation.slcio ]; then
   ddsim \
     --steeringFile clic_steer.py \
     --inputFiles ../Tests/yyxyev_000.stdhep -N 4 \
-    --compactFile $ILCSOFT/lcgeo/HEAD/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
+    --compactFile $LCGEO/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml \
     --outputFile testSimulation.slcio
 fi
 
@@ -35,7 +35,7 @@ sed -i 's;# algList.append(OverlayFalse);algList.append(OverlayFalse);' clicReco
 sed -i 's;# algList.append(MyConformalTracking);algList.append(MyConformalTracking);' clicReconstruction.py
 sed -i 's;# algList.append(ClonesAndSplitTracksFinder);algList.append(ClonesAndSplitTracksFinder);' clicReconstruction.py
 sed -i 's;# algList.append(RenameCollection);algList.append(RenameCollection);' clicReconstruction.py
-sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", os.environ["ILCSOFT"]+"/lcgeo/HEAD/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
+sed -i 's;"DD4hepXMLFile", ".*",; "DD4hepXMLFile", os.environ["LCGEO"]+"/CLIC/compact/CLIC_o3_v14/CLIC_o3_v14.xml",;' clicReconstruction.py
 # Change output level for correct test confirmation
 sed -i 's;OutputLevel=WARNING; OutputLevel=DEBUG;' clicReconstruction.py
 

--- a/test/scripts/test_gmp2.sh
+++ b/test/scripts/test_gmp2.sh
@@ -7,6 +7,9 @@ fi
 
 if [ ! -f $GMP_tests_DIR/inputFiles/testSimulation.slcio ]; then
   echo "Input file not found. Generating one..."
+  if [ -z ${ILCSOFT} ]; then
+    ILCSOFT="/cvmfs/clicdp.cern.ch/iLCSoft/lcg/97/nightly/x86_64-centos7-gcc8-opt"
+  fi
   ddsim \
     --steeringFile $ILCSOFT/ClicPerformance/HEAD/clicConfig/clic_steer.py \
     --inputFiles $ILCSOFT/ClicPerformance/HEAD/Tests/yyxyev_000.stdhep -N 4 \


### PR DESCRIPTION
BEGINRELEASENOTES
- Change compilation to use CMVFS HSF repository
- Remove Gaudi compilation for CI
- Adapt tests to use new environment variables

ENDRELEASENOTES
